### PR TITLE
fix: BinanceWebSocketCollectorTest 누락된 import 문 추가 (#1)

### DIFF
--- a/fds-core/src/test/java/com/fds/core/collector/BinanceWebSocketCollectorTests.java
+++ b/fds-core/src/test/java/com/fds/core/collector/BinanceWebSocketCollectorTests.java
@@ -1,5 +1,7 @@
 package com.fds.core.collector;
 
+import com.fds.core.collector.BinanceWebSocketCollector;
+import com.fds.core.collector.BinanceWebSocketProperties;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
- BinanceWebSocketCollector와 BinanceWebSocketProperties의 명시적 import 추가
- 컴파일러가 심볼을 찾지 못하던 컴파일 오류 해결
- compileTestJava 태스크가 성공적으로 완료되도록 수정